### PR TITLE
RT-63 disconnect packet

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -57,6 +57,7 @@ int main(int ac, char **av)
     world.addSystem<ECS::Utils::Vector2f, Component::TypeEntity, Component::IsAlive, Component::HitBox>(
         ECS::System::botHit);
     world.addSystem<Component::TypeEntity, Component::IsAlive, Component::LoadedSprite>(ECS::System::triggerBotDeath);
+    world.addSystem<Component::TypeEntity>(ECS::System::triggerBotDisconnect);
 
     // Player systems
     world.addSystem<ECS::Utils::Vector2f, Component::Speed, Component::TypeEntity, Component::IsAlive>(

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -93,6 +93,10 @@ int main(int ac, char **av)
         eventManager->clearNonGameEvents();
         world.calcDeltaTime();
     }
+
+    // Quit server properly
+    RType::Packet disconnectPacket(static_cast<int>(RType::ServerEventType::DISCONNECT));
+    client.send(disconnectPacket);
     Network::NetworkHandler::getInstance().stop();
     return 0;
 }

--- a/src/client/systems/System.hpp
+++ b/src/client/systems/System.hpp
@@ -174,6 +174,11 @@ namespace ECS {
                                         Core::SparseArray<Component::IsAlive> &aIsAlive,
                                         Core::SparseArray<Component::LoadedSprite> &aSprites);
 
+            /**
+             * @brief Handle the disconnection of a player (triggered by server)
+             */
+            static void triggerBotDisconnect(Core::SparseArray<Component::TypeEntity> &aType);
+
         private:
             /**
              * @brief Map of all the SDL_Keycode and their equivalent in our ECS

--- a/src/client/systems/bot/CMakeLists.txt
+++ b/src/client/systems/bot/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(client PRIVATE
         System+TriggerBotShoot.cpp
         System+BotHit.cpp
         System+TriggerBotDeath.cpp
+        System+TriggerBotDisconnect.cpp
 )
 
 target_include_directories(client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/client/systems/bot/System+TriggerBotDisconnect.cpp
+++ b/src/client/systems/bot/System+TriggerBotDisconnect.cpp
@@ -1,0 +1,26 @@
+#include "ClientGameEvent.hpp"
+#include "EventManager.hpp"
+#include "System.hpp"
+#include "TypeUtils.hpp"
+
+namespace ECS {
+    void System::triggerBotDisconnect(Core::SparseArray<Component::TypeEntity> &aType)
+    {
+        auto &world = Core::World::getInstance();
+        Event::EventManager *eventManager = Event::EventManager::getInstance();
+        auto events = eventManager->getEventsByType(Event::EventType::GAME);
+
+        for (auto &event : events) {
+            auto &gameEvent = static_cast<RType::ClientGameEvent &>(*event);
+
+            if (gameEvent.getType() == RType::ClientEventType::PLAYER_DISCONNECTION) {
+                size_t onlineBotId = static_cast<size_t>(gameEvent.getPayload()[0]);
+                size_t localBotId = RType::TypeUtils::getInstance().getEntityIdByOnlineId(aType, onlineBotId);
+                world.killEntity(localBotId);
+
+                eventManager->removeEvent(event);
+                std::cout << "Player " << onlineBotId << " disconnected" << std::endl;
+            }
+        }
+    }
+} // namespace ECS

--- a/src/client/systems/enemy/System+MoveEnemy.cpp
+++ b/src/client/systems/enemy/System+MoveEnemy.cpp
@@ -7,6 +7,7 @@ namespace ECS {
                            Core::SparseArray<Component::TypeEntity> &aType)
     {
         auto &world = Core::World::getInstance();
+        auto &display = SDLDisplayClass::getInstance();
 
         for (size_t idx = 0; idx < aPos.size(); idx++) {
             if (!aPos[idx].has_value()) {
@@ -18,7 +19,7 @@ namespace ECS {
             if (type.isEnemy) {
                 pos.x -= speed.speed * world.getDeltaTime();
                 if (pos.x < -30) {
-                    SDLDisplayClass::getInstance().freeRects(idx);
+                    display.freeRects(idx);
                     world.killEntity(idx);
                 }
             }

--- a/src/client/systems/missile/System+MoveMissiles.cpp
+++ b/src/client/systems/missile/System+MoveMissiles.cpp
@@ -8,6 +8,7 @@ namespace ECS {
                               Core::SparseArray<Component::TypeEntity> &aType)
     {
         auto &world = Core::World::getInstance();
+        auto &display = SDLDisplayClass::getInstance();
 
         for (size_t idx = 0; idx < aPos.size(); idx++) {
             if (!aPos[idx].has_value() || !aSpeed[idx].has_value() || !aType[idx].has_value()) {
@@ -23,7 +24,7 @@ namespace ECS {
                     pos.x += speed.speed * world.getDeltaTime();
                 }
                 if (pos.x > SCREEN_WIDTH + 30 || pos.x < -30) {
-                    SDLDisplayClass::getInstance().freeRects(idx);
+                    display.freeRects(idx);
                     world.killEntity(idx);
                 }
             }

--- a/src/rtype/events/ClientGameEvent.hpp
+++ b/src/rtype/events/ClientGameEvent.hpp
@@ -15,8 +15,8 @@ namespace RType {
         PLAYER_SHOOT = 3,
         PLAYER_DEATH = 4,
         ENEMY_SPAWN = 5,
-        ENEMY_DEATH = 6,
-        ENEMY_SHOOT = 7,
+        ENEMY_SHOOT = 6,
+        ENEMY_DEATH = 7,
     };
 
     /**

--- a/src/rtype/events/ServerGameEvent.hpp
+++ b/src/rtype/events/ServerGameEvent.hpp
@@ -12,9 +12,8 @@ namespace RType {
     {
         CONNECT = 0,
         DISCONNECT = 1,
-        CRASH = 2,
-        MOVE = 3,
-        SHOOT = 4
+        MOVE = 2,
+        SHOOT = 3
     };
 
     /**

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -42,6 +42,7 @@ int main(int ac, char **av)
         world.addSystem<ECS::Utils::Vector2f, Component::TypeEntity, Component::IsAlive, Component::HitBox>(
             ECS::System::playerHit);
         world.addSystem<Component::TypeEntity, Component::IsAlive>(ECS::System::killPlayer);
+        world.addSystem(ECS::System::disconnectPlayer);
 
         // Enemy systems
         world.addSystem<ECS::Utils::Vector2f, Component::Speed, Component::TypeEntity, Component::HitBox,

--- a/src/server/network/ServerHandler.cpp
+++ b/src/server/network/ServerHandler.cpp
@@ -53,6 +53,11 @@ namespace Network {
         std::cout << "Player " << aClientId << " joined" << std::endl;
     }
 
+    void ServerHandler::removeClient(std::size_t aClientId)
+    {
+        _clients.erase(aClientId);
+    }
+
     int ServerHandler::getNumberClients() const
     {
         return _clients.size();

--- a/src/server/network/ServerHandler.hpp
+++ b/src/server/network/ServerHandler.hpp
@@ -61,6 +61,12 @@ namespace Network {
             void addClient(std::size_t, udp::endpoint);
 
             /**
+             * @brief Remove a client from the server
+             * @param aClientId The id of the client to remove
+             */
+            void removeClient(std::size_t);
+
+            /**
              * @brief Get the number of clients connected to the server
              * @return int The number of clients connected to the server
              */

--- a/src/server/systems/System.hpp
+++ b/src/server/systems/System.hpp
@@ -69,6 +69,11 @@ namespace ECS {
                                    Core::SparseArray<Component::IsAlive> &aIsAlive);
 
             /**
+             * @brief Disconnect the player from the server
+             */
+            static void disconnectPlayer();
+
+            /**
              * @brief Spawn enemies
              *
              * @param aPos SparseArray of all entities position

--- a/src/server/systems/player/CMakeLists.txt
+++ b/src/server/systems/player/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(server PRIVATE
         System+PlayerShoot.cpp
         System+PlayerHit.cpp
         System+KillPlayer.cpp
+        System+DisconnectPlayer.cpp
 )
 
 target_link_libraries(server

--- a/src/server/systems/player/System+DisconnectPlayer.cpp
+++ b/src/server/systems/player/System+DisconnectPlayer.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include "Components.hpp"
+#include "Event.hpp"
+#include "EventManager.hpp"
+#include "Packets.hpp"
+#include "ServerGameEvent.hpp"
+#include "ServerHandler.hpp"
+#include "System.hpp"
+#include "World.hpp"
+
+namespace ECS {
+    void System::disconnectPlayer()
+    {
+        Core::World &world = Core::World::getInstance();
+        ECS::Event::EventManager *eventManager = ECS::Event::EventManager::getInstance();
+        Network::ServerHandler &server = Network::ServerHandler::getInstance();
+        auto events = eventManager->getEventsByType(Event::EventType::GAME);
+
+        for (auto &event : events) {
+            auto &gameEvent = static_cast<RType::ServerGameEvent &>(*event);
+            if (gameEvent.getType() == RType::ServerEventType::DISCONNECT) {
+                size_t playerId = gameEvent.getEntityId();
+
+                world.killEntity(playerId);
+                server.removeClient(playerId);
+
+                server.broadcast(static_cast<int>(RType::ClientEventType::PLAYER_DISCONNECTION),
+                                 {static_cast<float>(playerId)});
+
+                eventManager->removeEvent(event);
+
+                std::cout << "Player " << playerId << " left" << std::endl;
+            }
+        }
+    }
+} // namespace ECS


### PR DESCRIPTION
## Describe your changes

- Client sends `DISCONNECT` packet before quit
- Server broadcasts `PLAYER_DISCONNECTION` packet and kills entity when receive `DISCONNECT`
- Clients kill bot entity when receiving `PLAYER_DISCONNECTION` packet from server

## Issue ticket number and link

RT-63 https://uwuclub.atlassian.net/browse/RT-63?atlOrigin=eyJpIjoiNDdkN2NkZjEzNTcyNDI1YzgzYWY1ZDIyNTU0NmM0ZjMiLCJwIjoiaiJ9

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have documented my code
- [ ] Do we need to implement unit tests?